### PR TITLE
Publishing of assets delegated to End Users

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>dev.truthchain</groupId>
 	<artifactId>api</artifactId>
-	<version>0.1.3.2</version>
+	<version>0.2.3.0</version>
 	<name>api</name>
 	<description>Truthchain API</description>
 	<properties>

--- a/src/main/java/dev/truthchain/api/assets/SnippetAsset.java
+++ b/src/main/java/dev/truthchain/api/assets/SnippetAsset.java
@@ -6,6 +6,7 @@ import dev.truthchain.api.entities.Snippet;
 import lombok.*;
 
 import java.util.Date;
+import java.util.UUID;
 
 @Getter @Setter
 @AllArgsConstructor @NoArgsConstructor
@@ -49,5 +50,15 @@ public class SnippetAsset {
         this.url = snippet.getUrl();
         this.title = snippet.getTitle();
         this.createdAt = snippet.getCreatedAt();
+    }
+
+    public Snippet toSnippet() {
+        return Snippet.builder()
+                .id(UUID.fromString(this.id.replace("https://api.truthchain.dev/snippets/", "")))
+                .content(this.content)
+                .url(this.url)
+                .title(this.title)
+                .createdAt(this.createdAt)
+                .build();
     }
 }

--- a/src/main/java/dev/truthchain/api/controllers/SnippetsApiController.java
+++ b/src/main/java/dev/truthchain/api/controllers/SnippetsApiController.java
@@ -33,8 +33,7 @@ public class SnippetsApiController {
             @PathVariable UUID id,
             @RequestBody Snippet snippet
     ) {
-        // TODO: return snippetService.update(id, snippet);
-        return null;
+        return snippetService.update(id, snippet);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/dev/truthchain/api/entities/Snippet.java
+++ b/src/main/java/dev/truthchain/api/entities/Snippet.java
@@ -23,7 +23,7 @@ public class Snippet {
     private String content;
     private String type;
 
-    @Column(columnDefinition = "NVARCHAR")
+    @Column(columnDefinition = "NVARCHAR MAX")
     private String url;
     private Date createdAt;
 
@@ -49,6 +49,7 @@ public class Snippet {
     public enum StatusError {
         NOT_VERIFIABLE,
         NOT_SAVED_TO_DKG,
+        NOT_VERIFIED_ON_DKG,
     }
 
 }

--- a/src/main/resources/templates/snippet.html
+++ b/src/main/resources/templates/snippet.html
@@ -52,14 +52,6 @@
                     <td th:text="${snippet.content}"></td>
                 </tr>
                 <tr>
-                    <td class="cloumn-name">Author</td>
-                    <td th:text="${snippet.account}"></td>
-                </tr>
-                <tr>
-                    <td class="cloumn-name">Signature</td>
-                    <td th:text="${snippet.signature}"></td>
-                </tr>
-                <tr>
                     <td class="cloumn-name">Created At</td>
                     <td th:text="${snippet.createdAt}"></td>
                 </tr>

--- a/src/test/java/dev/truthchain/api/services/DkgServiceTest.java
+++ b/src/test/java/dev/truthchain/api/services/DkgServiceTest.java
@@ -6,6 +6,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 @Disabled("DKG Service requires a valid running DKG node and API key to run")
 public class DkgServiceTest extends AbstractServiceTest {
 
@@ -27,6 +32,20 @@ public class DkgServiceTest extends AbstractServiceTest {
             var savedSnippet = snippetService.create(snippet);
 
             dkgService.createAsset(savedSnippet);
+        }
+    }
+
+    @Nested
+    @DisplayName("read asset")
+    public class readAsset {
+
+        @Test
+        @DisplayName("valid snippet should read dkg asset")
+        public void validSnippet__shouldReadAsset() {
+            Snippet dkgSnippet = dkgService.readAsset("did:dkg:otp/0x1a061136ed9f5ed69395f18961a0a535ef4b3e5f/1190732");
+
+            assertNotNull(dkgSnippet);
+            assertEquals(dkgSnippet.getId(), UUID.fromString("d40a8dc2-e757-4226-8d1e-d8fdd8f355b8"));
         }
     }
 }


### PR DESCRIPTION
### Description
Publishing of assets is now done by users, and Truthchain than validates if published assets match to initial request and update status accordingly.

#### New Algorithm
   1. User submits snippet to Truthchain
   2. Snippet is created in Database and status is set to `CREATED`
   3. User publishes asset to DKG using their wallet
   4. Extension sends PATCH request with Snippet's UAL
       a) UAL is updated for that particular Snippet and status is set to `PUBLISHED`
       b) Snippet is read from DKG and data is validated
       c) If Snippets match the status is set to `VALIDATED` if not Snippet's `error` field is populated